### PR TITLE
Use https fetching gems from GitHub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'ruby-prof', platforms: [:ruby_22, :ruby_23, :ruby_24]
 
 gem 'rake', '>= 12.3', '< 14.0'
-gem 'metric_fu', github: 'metricfu/metric_fu', branch: 'main'
+gem 'metric_fu', git: 'https://github.com/metricfu/metric_fu', branch: 'main'
 
 gemspec


### PR DESCRIPTION
`github: 'metricfu/metric_fu'` failed to load on `bundle install`.

It has been changed a long time ago to `git: "https://` - see https://bundler.io/guides/git.html
