### PR TITLE
Add option to not bind the queue to an exchange

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -39,7 +39,7 @@ class Sneakers::Queue
 
     queue = @channel.queue(@name, **@opts[:queue_options])
 
-    if exchange_name.length > 0
+    if @opts[:bind] != false && exchange_name.length > 0
       routing_keys.each do |key|
         if @opts[:bind_arguments]
           queue.bind(@exchange, routing_key: key, arguments: @opts[:bind_arguments])


### PR DESCRIPTION
Takes care of https://github.com/jondot/sneakers/issues/365

Indeed, there is no need for creating bindings when the topology is defined manually and store in schema definitions, and, moreover, when the workers are only going to consume.
