### PR TITLE
Load `ActiveJob adapter` only for rails >= 7.2

### DIFF
--- a/kicks.gemspec
+++ b/kicks.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rake', '>= 12.3', '< 14.0'
 
   # for integration environment (see .travis.yml and integration_spec)
-  gem.add_development_dependency 'activejob', '>= 7.1'
-  gem.add_development_dependency 'activesupport', '>= 7.1'
+  gem.add_development_dependency 'activejob', '>= 7.2'
+  gem.add_development_dependency 'activesupport', '>= 7.2'
   gem.add_development_dependency 'rabbitmq_http_api_client'
   gem.add_development_dependency 'redis'
 

--- a/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -1,37 +1,39 @@
-module ActiveJob
-  module QueueAdapters
-    # Explicitly remove the implementation existing in older rails'.
-    remove_const(:SneakersAdapter) if defined?(:SneakersAdapter)
+if defined?(ActiveJob) && ActiveJob.version >= "7.2"
+  module ActiveJob
+    module QueueAdapters
+      # Explicitly remove the implementation existing in older Rails versions'.
+      remove_const(:SneakersAdapter) if defined?("::#{name}::SneakersAdapter")
 
-    # = Sneakers adapter for Active Job
-    #
-    # To use Sneakers set the queue_adapter config to +:sneakers+.
-    #
-    #   Rails.application.config.active_job.queue_adapter = :sneakers
-    class SneakersAdapter < ::ActiveJob::QueueAdapters::AbstractAdapter
-      def initialize
-        @monitor = Monitor.new
-      end
-
-      def enqueue(job)
-        @monitor.synchronize do
-          JobWrapper.from_queue job.queue_name
-          JobWrapper.enqueue ActiveSupport::JSON.encode(job.serialize)
+      # = Sneakers adapter for Active Job
+      #
+      # To use Sneakers set the queue_adapter config to +:sneakers+.
+      #
+      #   Rails.application.config.active_job.queue_adapter = :sneakers
+      class SneakersAdapter < ::ActiveJob::QueueAdapters::AbstractAdapter
+        def initialize
+          @monitor = Monitor.new
         end
-      end
 
-      def enqueue_at(job, timestamp)
-        raise NotImplementedError, 'This queueing backend does not support scheduling jobs.'
-      end
+        def enqueue(job)
+          @monitor.synchronize do
+            JobWrapper.from_queue job.queue_name
+            JobWrapper.enqueue ActiveSupport::JSON.encode(job.serialize)
+          end
+        end
 
-      class JobWrapper
-        include Sneakers::Worker
-        from_queue 'default'
+        def enqueue_at(job, timestamp)
+          raise NotImplementedError, 'This queueing backend does not support scheduling jobs.'
+        end
 
-        def work(msg)
-          job_data = ActiveSupport::JSON.decode(msg)
-          Base.execute job_data
-          ack!
+        class JobWrapper
+          include Sneakers::Worker
+          from_queue 'default'
+
+          def work(msg)
+            job_data = ActiveSupport::JSON.decode(msg)
+            Base.execute job_data
+            ack!
+          end
         end
       end
     end


### PR DESCRIPTION
Rails introduced `ActiveJob::QueueAdapters::AbstratAdapter` in 7.2 version.

So this PR conditionally loads "in-house" adapter only if `activejob` version is >= 7.2. If version is less than 7.2 adapter implemented inside the rails will be used.