### PR TITLE
 Maxretry handler with {} queue option Argument should return false

### DIFF
--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -87,7 +87,7 @@ module Sneakers
         opt_args = if opts.dig(:queue_options, :arguments).blank?
                     {}
                    else
-                    opts[:queue_options][:arguments].transform_keys(&:to_sym)
+                    opts.dig(:queue_options, :arguments).transform_keys(&:to_sym)
                    end
         opts[:queue_options][:arguments] = { :'x-dead-letter-exchange' => retry_name }.merge(opt_args)
         opts[:queue_options]

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -84,7 +84,7 @@ module Sneakers
 
       def self.configure_queue(name, opts)
         retry_name = opts.fetch(:retry_exchange, "#{name}-retry")
-        opt_args = if opts[:queue_options][:arguments].blank?
+        opt_args = if opts.dig(:queue_options, :arguments).blank?
                     {}
                    else
                     opts[:queue_options][:arguments].transform_keys(&:to_sym)

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -89,7 +89,7 @@ module Sneakers
                    else
                     opts.dig(:queue_options, :arguments).transform_keys(&:to_sym)
                    end
-        opts[:queue_options][:arguments] = { :'x-dead-letter-exchange' => retry_name }.merge(opt_args)
+        opts[:queue_options][:arguments] = { :'x-dead-letter-exchange' => retry_name }.merge!(opt_args)
         opts[:queue_options]
       end
 

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -84,7 +84,11 @@ module Sneakers
 
       def self.configure_queue(name, opts)
         retry_name = opts.fetch(:retry_exchange, "#{name}-retry")
-        opt_args = opts[:queue_options][:arguments] ? opts[:queue_options][:arguments].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo} : {}
+        opt_args = if opts[:queue_options][:arguments].blank?
+                    {}
+                   else
+                    opts[:queue_options][:arguments].transform_keys(&:to_sym)
+                   end
         opts[:queue_options][:arguments] = { :'x-dead-letter-exchange' => retry_name }.merge(opt_args)
         opts[:queue_options]
       end


### PR DESCRIPTION
When opts[:queue_options][:arguments] have an empty hash {}, it should return false.