### PR TITLE
Correctly remove the buildin rails adapter

### DIFF
--- a/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -2,7 +2,7 @@ if defined?(ActiveJob) && ActiveJob.version >= "7.2"
   module ActiveJob
     module QueueAdapters
       # Explicitly remove the implementation existing in older Rails versions'.
-      remove_const(:SneakersAdapter) if defined?("::#{name}::SneakersAdapter")
+      remove_const(:SneakersAdapter) if const_defined?(:SneakersAdapter)
 
       # = Sneakers adapter for Active Job
       #


### PR DESCRIPTION
Followup #19. cc @dixpac

`defined?` for a string literal is always truthy, same as for symbols.
`defined?(ActiveJob::QueueAdapters::SneakersAdapter)` would work as an alternative.

```rb
module ActiveJob
  module QueueAdapters
    # Adapter removed from rails
  end
end

module ActiveJob
  module QueueAdapters
    remove_const(:SneakersAdapter) if defined?("::#{name}::SneakersAdapter")
  end
end
```

`test.rb:10:in 'remove_const': constant ActiveJob::QueueAdapters::SneakersAdapter not defined (NameError)`