### PR TITLE
Fix error in Gem version comparison

### DIFF
--- a/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -1,4 +1,4 @@
-if defined?(ActiveJob) && ActiveJob.version >= "7.2"
+if defined?(ActiveJob) && ActiveJob.version >= Gem::Version.new("7.2")
   module ActiveJob
     module QueueAdapters
       # Explicitly remove the implementation existing in older Rails versions'.


### PR DESCRIPTION
Gem::Version can be compared with another Gem::Version, not with string. It were caused crash on the boot time:

`/srv/endpoints/vendor/ruby/3.0.0/gems/kicks-3.1.1/lib/active_job/queue_adapters/sneakers_adapter.rb:2:in `>': comparison of Gem::Version with String failed (ArgumentError)
        from /srv/endpoints/vendor/ruby/3.0.0/gems/kicks-3.1.1/lib/active_job/queue_adapters/sneakers_adapter.rb:2:in `<top (required)>'
        from /srv/endpoints/vendor/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:332:in `require'
        from /srv/endpoints/vendor/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:332:in `block in require'
        from /srv/endpoints/vendor/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:299:in `load_dependency'
        from /srv/endpoints/vendor/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:332:in `require'
        from /srv/endpoints/vendor/ruby/3.0.0/gems/kicks-3.1.1/lib/sneakers.rb:25:in `<top (required)>'
        from /srv/endpoints/vendor/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/dependencies.rb:332:in `require'
...`