### PR TITLE
Relax ActiveJob version constraint

### DIFF
--- a/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -1,39 +1,37 @@
-if defined?(ActiveJob) && ActiveJob.version >= Gem::Version.new("7.2")
-  module ActiveJob
-    module QueueAdapters
-      # Explicitly remove the implementation existing in older Rails versions'.
-      remove_const(:SneakersAdapter) if const_defined?(:SneakersAdapter)
+module ActiveJob
+  module QueueAdapters
+    # Explicitly remove the implementation existing in older Rails versions'.
+    remove_const(:SneakersAdapter) if const_defined?(:SneakersAdapter)
 
-      # = Sneakers adapter for Active Job
-      #
-      # To use Sneakers set the queue_adapter config to +:sneakers+.
-      #
-      #   Rails.application.config.active_job.queue_adapter = :sneakers
-      class SneakersAdapter < ::ActiveJob::QueueAdapters::AbstractAdapter
-        def initialize
-          @monitor = Monitor.new
+    # = Sneakers adapter for Active Job
+    #
+    # To use Sneakers set the queue_adapter config to +:sneakers+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :sneakers
+    class SneakersAdapter
+      def initialize
+        @monitor = Monitor.new
+      end
+
+      def enqueue(job)
+        @monitor.synchronize do
+          JobWrapper.from_queue job.queue_name
+          JobWrapper.enqueue ActiveSupport::JSON.encode(job.serialize)
         end
+      end
 
-        def enqueue(job)
-          @monitor.synchronize do
-            JobWrapper.from_queue job.queue_name
-            JobWrapper.enqueue ActiveSupport::JSON.encode(job.serialize)
-          end
-        end
+      def enqueue_at(job, timestamp)
+        raise NotImplementedError, 'This queueing backend does not support scheduling jobs.'
+      end
 
-        def enqueue_at(job, timestamp)
-          raise NotImplementedError, 'This queueing backend does not support scheduling jobs.'
-        end
+      class JobWrapper
+        include Sneakers::Worker
+        from_queue 'default'
 
-        class JobWrapper
-          include Sneakers::Worker
-          from_queue 'default'
-
-          def work(msg)
-            job_data = ActiveSupport::JSON.decode(msg)
-            Base.execute job_data
-            ack!
-          end
+        def work(msg)
+          job_data = ActiveSupport::JSON.decode(msg)
+          Base.execute job_data
+          ack!
         end
       end
     end


### PR DESCRIPTION
Initially gem checked for existence of active_job >=7.2, mainly because of `ActiveJob::QueueAdapters::AbstractAdapter`.

But since that [class](https://github.com/rails/rails/blob/main/activejob/lib/active_job/queue_adapters/abstract_adapter.rb) is base adapter with contract for `enqueue` and `enqueue_at` we don't have to inherit from it. This should allow other rails versions to work.