### PR TITLE
Allow connection option to be callable

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -19,8 +19,12 @@ class Sneakers::Queue
     # If we've already got a bunny object, use it.  This allows people to
     # specify all kinds of options we don't need to know about (e.g. for ssl).
     @bunny = @opts[:connection]
-    @bunny ||= create_bunny_connection
-    @bunny.start
+    if @bunny.respond_to?(:call)
+      @bunny = @bunny.call
+    else
+      @bunny ||= create_bunny_connection
+      @bunny.start
+    end
 
     @channel = @bunny.create_channel
     @channel.prefetch(@opts[:prefetch])

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -104,7 +104,7 @@ describe Sneakers::Publisher do
         exchange = Object.new
         existing_session = Bunny.new
 
-        mock(existing_session).start
+        mock(existing_session).start { existing_session }
         mock(existing_session).create_channel { channel }
 
         mock(channel).exchange('another_exchange', type: :topic, durable: false, :auto_delete => false, arguments: { 'x-arg' => 'value' }) do
@@ -124,15 +124,15 @@ describe Sneakers::Publisher do
         @existing_session = existing_session
       end
 
-      it 'can handle an existing connection that is offline' do
+      it 'can handle an existing connection object' do
         p = Sneakers::Publisher.new
         p.publish('test msg', my_vars)
         _(p.instance_variable_get(:@bunny)).must_equal @existing_session
       end
 
-      it 'can handle an existing connection that is online' do
-        mock(@existing_session).connected? { true }
-        p = Sneakers::Publisher.new
+      it 'can handle an existing connection function' do
+        @existing_session.start
+        p = Sneakers::Publisher.new(connection: ->() { @existing_session })
         p.publish('test msg', my_vars)
         _(p.instance_variable_get(:@bunny)).must_equal @existing_session
       end


### PR DESCRIPTION
This change allows `:connection` option to be callable and avoid calling `start` on bunny sessions.