### PR TITLE
Pass logger configuration values through to logger initialization

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -46,11 +46,11 @@ module Sneakers
     @configured = false
   end
 
-  def daemonize!(loglevel=Logger::INFO)
+  def daemonize!(loglevel=nil)
     CONFIG[:log] = 'sneakers.log'
+    CONFIG[:log_level] = loglevel || Logger::INFO
     CONFIG[:daemonize] = true
     setup_general_logger!
-    logger.level = loglevel
   end
 
   def rake_worker_classes=(worker_classes)
@@ -124,4 +124,3 @@ module Sneakers
     @publisher = Sneakers::Publisher.new
   end
 end
-

--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -109,7 +109,7 @@ module Sneakers
     if [:info, :debug, :error, :warn].all?{ |meth| CONFIG[:log].respond_to?(meth) }
       @logger = CONFIG[:log]
     else
-      @logger = ServerEngine::DaemonLogger.new(CONFIG[:log])
+      @logger = ServerEngine::DaemonLogger.new(CONFIG[:log], CONFIG.slice(:log_level, :log_rotate_age, :log_rotate_size))
       @logger.formatter = Sneakers::Support::ProductionFormatter
     end
   end

--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -35,6 +35,11 @@ module Sneakers
       :log                => STDOUT,
       :pid_path           => 'sneakers.pid',
       :amqp_heartbeat     => 30,
+      
+      # Default values from serverengine
+      :log_rotate_age     => 5,
+      :log_rotate_size    => 1048576,
+      :log_level          => 'debug',
 
       # workers
       :prefetch           => 10,

--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -5,7 +5,7 @@ module Sneakers
   class Configuration
 
     extend Forwardable
-    def_delegators :@hash, :to_hash, :[], :[]=, :==, :fetch, :delete, :has_key?, :dig
+    def_delegators :@hash, :to_hash, :[], :[]=, :==, :fetch, :delete, :has_key?, :dig, :slice
 
     EXCHANGE_OPTION_DEFAULTS = {
       :type               => :direct,

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -218,7 +218,10 @@ describe Sneakers::Worker do
           :hooks => {},
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 30,
-          :amqp_heartbeat => 30
+          :amqp_heartbeat => 30,
+          :log_rotate_age => 5,
+          :log_rotate_size => 1048576,
+          :log_level => "debug"
         )
       end
 
@@ -256,7 +259,10 @@ describe Sneakers::Worker do
           :hooks => {},
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 5,
-          :amqp_heartbeat => 30
+          :amqp_heartbeat => 30,
+          :log_rotate_age => 5,
+          :log_rotate_size => 1048576,
+          :log_level => "debug"
         )
       end
 
@@ -294,7 +300,10 @@ describe Sneakers::Worker do
           :hooks => {},
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 30,
-          :amqp_heartbeat => 30
+          :amqp_heartbeat => 30,
+          :log_rotate_age => 5,
+          :log_rotate_size => 1048576,
+          :log_level => "debug"
         )
       end
     end


### PR DESCRIPTION
This MR adds three new configuration keys (and their default values) to `Sneakers.configuration` that are passed through to the logger. These keys are:

-  log_rotate_age  (Default: 5)
-  log_rotate_size  (Default: 1048576 [1 MB])
-  log_level  (Default: 'debug')

A test had to be updated to expect these keys, but I did not see a place to add testing the affect.  Willing to push tests where appropriate.

https://github.com/ruby-amqp/kicks/issues/33