### PR TITLE
Handle and re-raise bunny exceptions during work

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -76,7 +76,7 @@ module Sneakers
           end
           res = block_to_call.call(deserialized_msg, delivery_info, metadata, handler)
         end
-      rescue SignalException, SystemExit
+      rescue SignalException, SystemExit, Bunny::Exception
         # ServerEngine handles these exceptions, so they are not expected to be raised within the worker.
         # Nevertheless, they are listed here to ensure that they are not caught by the rescue block below.
         raise

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -446,6 +446,14 @@ describe Sneakers::Worker do
       w.do_work(header, nil, "msg", handler)
     end
 
+    it "should not catch bunny exceptions" do
+      w = DummyWorker.new(@queue, TestPool.new)
+      mock(w).work("msg").once{ raise Bunny::Exception }
+      assert_raises(Bunny::Exception) do
+        w.do_work(nil, nil, "msg", nil)
+      end
+    end
+
     it "should log exceptions from workers" do
       handler = Object.new
       header = Object.new


### PR DESCRIPTION
Custom workers which perform bunny related operations inside the `work` function through the `handler` can find themselves getting stuck when rabbitmq is restarted.

This can happen because the bunny exception raised by the `work` function is caught by the catch all rescue present in `process_work` function - and this does not let the exception bubble up leaving bunny in broken state and not receiving any more jobs.

This PR allows Bunny::Exception to be re-raised so that the worker does not get stuck.

My use case involves allowing the ActiveJob to configure whether ack would be sent before or after the job (so that the Job can decide on at lease once or at most once paradigm). The jobs which were sending ack early through the work function would raise this exception and the worker would get stuck.